### PR TITLE
Fix missing semicolons in spinbutton.css

### DIFF
--- a/gtk-3.20/widgets/spinbutton.css
+++ b/gtk-3.20/widgets/spinbutton.css
@@ -3,7 +3,7 @@
  **************/
 spinbutton button {
 
-    color: @text_color_disabled
+    color: @text_color_disabled;
     padding: 2px 4px;
     border-width: 2px;
     border-color: transparent;
@@ -33,7 +33,7 @@ spinbutton.vertical button {
 
     border-width: 1px;
     border-style: none;
-    color: @text_color_disabled
+    color: @text_color_disabled;
     background-image: none;
     box-shadow: none;
 }
@@ -61,7 +61,7 @@ spinbutton.vertical button:active:hover:focus {
 
 spinbutton.vertical button:disabled {
     background-image: none;
-    color: @text_color_disabled
+    color: @text_color_disabled;
     background-image: none;
 }
 


### PR DESCRIPTION
Hey, thanks for the theme.
Gtk throws some errors when running any gtk program with this theme applied. I have tracked down the issue to a couple missing semicolons on gtk3.20 spinbutton.css